### PR TITLE
Fixed support for MacOS >= 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# NOTE
-
-SwiftScripting is known to be broken on macOS 13 or later.
-
-
 # SwiftScripting
 Utilities and samples to aid in using Swift with the Scripting Bridge
 

--- a/sbhc.py
+++ b/sbhc.py
@@ -36,6 +36,7 @@
 import sys
 import struct
 import re
+import platform
 
 from itertools import chain
 
@@ -257,7 +258,14 @@ class SBHeaderProcessor(object):
             self.category_dict[key] = category_items + children
 
     def emit_swift(self):
-        translation_unit = TranslationUnit.from_source(self.file_path, args=["-ObjC"])
+        cmakeArgs = ["-ObjC"]
+        if platform.system() == "Darwin":                                        # is Mac
+            macOsVersion = float('.'.join(platform.mac_ver()[0].split('.')[:2])) # poor man's version fetch
+            if macOsVersion >= 10.13:
+                cmakeArgs.append("-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/")
+                cmakeArgs.append("-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/")
+
+        translation_unit = TranslationUnit.from_source(self.file_path, args=cmakeArgs)
         self.swift_file = open('{}.swift'.format(self.app_name), 'w')
         for inclusion in translation_unit.get_includes():
             if inclusion.depth == 1:

--- a/sbhc.py
+++ b/sbhc.py
@@ -259,11 +259,10 @@ class SBHeaderProcessor(object):
 
     def emit_swift(self):
         cmakeArgs = ["-ObjC"]
-        if platform.system() == "Darwin":                                        # is Mac
-            macOsVersion = float('.'.join(platform.mac_ver()[0].split('.')[:2])) # poor man's version fetch
-            if macOsVersion >= 10.13:
-                cmakeArgs.append("-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/")
-                cmakeArgs.append("-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/")
+        macOsVersion = float('.'.join(platform.mac_ver()[0].split('.')[:2])) # poor man's version fetch
+        if macOsVersion >= 10.13:
+            cmakeArgs.append("-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/")
+            cmakeArgs.append("-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/")
 
         translation_unit = TranslationUnit.from_source(self.file_path, args=cmakeArgs)
         self.swift_file = open('{}.swift'.format(self.app_name), 'w')


### PR DESCRIPTION
# Bug Root Cause

1. Back in the day Apple decided to move things around filesystem-wise; and as a consequence many libraries, headers, etc. got scrambled in random directories
2. As a consequence, the headers included by the `sdp` generated headers weren't found
3. `clang.cindex` silently passed by the unknown types and so for years people might have pulled their hair quite rightfully over wtf is happening...

# Fix

1. Tell cmake where the frameworks are located
2. Tell cmake where the include dir is located
3. Do all this magic-cr*p only on the affected MacOS versions

# Disclaimer

While I admit it's quite a smelly solution to hard-code the location paths, as they are, I thought it's fine for this repository, as the cmake library path itself is also hardcoded ¯\_(ツ)_/¯ 
```
Config.set_library_path("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib")
```

# Further idea

Now that I got familiar with this fancy cmake api, objectiveC & swift as languages, and a bit of python, I believe it's a realistic assumption that generic handling should also be doable with cmake instead of string matching. I might come back in the future.